### PR TITLE
Use external prop-types package rather than React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "mocha": "^3.0.0",
     "phantomjs-polyfill": "0.0.2",
     "phantomjs-prebuilt": "^2.1.9",
+    "prop-types": "^15.5.0",
     "purecss": "^0.6.0",
     "react": "^15.2.1",
     "react-addons-test-utils": "^15.3.0",
@@ -75,6 +76,7 @@
     "webpack-merge": "^0.14.0"
   },
   "peerDependencies": {
+    "prop-types": ">= 15.5.0",
     "react": ">= 0.11.2 < 16.0.0",
     "react-dom": ">= 0.11.2 < 16.0.0"
   },

--- a/src/components/tooltip.js
+++ b/src/components/tooltip.js
@@ -1,5 +1,6 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 
 export default class Tooltip extends React.Component {
   static propTypes = {


### PR DESCRIPTION
React.PropTypes has moved into a different package since React v15.5. Because of that, deprecation warnings are also written to the devtools console and stdout when running tests:

```bash
console.error node_modules/fbjs/lib/warning.js:36
  Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
```

These changes uses that external prop-types package instead and adds it as part of peerDependencies.

Getting rid of these warnings would be really great! Any thoughts?

*Refs React docs for PropTypes: https://facebook.github.io/react/docs/typechecking-with-proptypes.html*